### PR TITLE
Hotfix/Fix vertical scroll bars on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,4 @@ Launches the test runner in the interactive watch mode.
 - `1.6.0` Improved web accessibility using <label> and aria-live="polite"
 - `1.7.0` Created dark mode for app using Tailwind CSS plus animated SVG toggle
 - `2.0.0` Reached 100% test coverage of lines by testing <ToggleDarkMode>
+- `2.0.1` Hotfix to remove vertical scroll bars on mobile caused by `h-screen`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-app-demo",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "dev": "next dev",
     "start": "next start",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -22,7 +22,7 @@ export default function App() {
   return (
     <>
       <ToggleDarkMode />
-      <div className="relative z-10 flex flex-col justify-end h-screen py-10 sm:justify-start">
+      <div className="relative z-10 flex flex-col justify-end h-[90vh] py-10 sm:justify-start">
         {/** place the search bar at bottom on mobile for improved UX */}
         <form
           className="flex flex-wrap items-center justify-center"


### PR DESCRIPTION
✅ fix: replace `h-screen` with `h-[90vh]` to remove vertical scrollbars on mobile caused by CSS viewport calculations
- _Note: no screenshots included, but manually tested to confirm this PR fixes the issue on Android Chrome (Google Pixel 3a_